### PR TITLE
[NOTICKET] Fix Tomcat security header

### DIFF
--- a/ix-portal-init.yaml
+++ b/ix-portal-init.yaml
@@ -61,7 +61,7 @@ spec:
         - name: TOMCAT_SEC_HEADER_XORIGINALURL
           value: allow
         - name: TOMCAT_SEC_HEADER_RECEIVEONNONLOOPBACKINTERFACE
-          value: allow
+          value: true
     volumes:
     - name: ixcloudapp-volume
       persistentVolumeClaim:

--- a/ix-portal-init.yaml
+++ b/ix-portal-init.yaml
@@ -61,7 +61,7 @@ spec:
         - name: TOMCAT_SEC_HEADER_XORIGINALURL
           value: allow
         - name: TOMCAT_SEC_HEADER_RECEIVEONNONLOOPBACKINTERFACE
-          value: true
+          value: "true"
     volumes:
     - name: ixcloudapp-volume
       persistentVolumeClaim:

--- a/ix-portal.yaml
+++ b/ix-portal.yaml
@@ -62,7 +62,7 @@ spec:
         - name: TOMCAT_SEC_HEADER_XORIGINALURL
           value: allow
         - name: TOMCAT_SEC_HEADER_RECEIVEONNONLOOPBACKINTERFACE
-          value: allow
+          value: "true"
     volumes:
     - name: ixcloudapp-volume
       persistentVolumeClaim:


### PR DESCRIPTION
With this change the Tomcat security header receiveOnNonLoopbackInterface will be set correctly to _true_ instead of _allow_.

<init-param>
 <description>
 Allow receiving security-sensitive headers on non-loopback network interfaces.
 Values: true or false (default).
 </description>
 <param-name>connector.security.header.receiveOnNonLoopbackInterface</param-name>
 <param-value>**true**</param-value>
</init-param>